### PR TITLE
In case if 'credentials_source' is equal to 'none', no credentials ar…

### DIFF
--- a/src/s3cli/config/config.go
+++ b/src/s3cli/config/config.go
@@ -30,6 +30,8 @@ const EmptyRegion = " "
 
 // StaticCredentialsSource specifies that credentials will be supplied using access_key_id and secret_access_key
 const StaticCredentialsSource = "static"
+// NoneCredentialsSource specifies that credentials will be empty. The blobstore client operates in read only mode.
+const NoneCredentialsSource = "none"
 
 const (
 	credentialsSourceEnvOrProfile = "env_or_profile"
@@ -76,6 +78,7 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 		if c.AccessKeyID != "" || c.SecretAccessKey != "" {
 			return S3Cli{}, errorStaticCredentialsPresent
 		}
+	case NoneCredentialsSource:
 	default:
 		return S3Cli{}, fmt.Errorf("Invalid credentials_source: %s", c.CredentialsSource)
 	}

--- a/src/s3cli/config/config_test.go
+++ b/src/s3cli/config/config_test.go
@@ -338,6 +338,16 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				Expect(err).To(MatchError("can't use access_key_id and secret_access_key with env_or_profile credentials_source"))
 			})
 		})
+
+		Context("when credentials source is `none`", func() {
+			It("validates that access key and secret key are equals to empty values", func() {
+				dummyJSONBytes := []byte(`{"bucket_name": "some-bucket", "credentials_source": "none"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				_, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
…e required.

Client works in read_only mode.

[#111414802](https://www.pivotaltracker.com/story/show/111414802)

Signed-off-by: Alexey Miroshkin <alexey.miroshkin@ru.ibm.com>