### PR TITLE
Accept server-side encryption options.

### DIFF
--- a/src/s3cli/client/client.go
+++ b/src/s3cli/client/client.go
@@ -88,15 +88,18 @@ func (client *S3Blobstore) Get(src string, dest io.WriterAt) error {
 
 // Put uploads a blob to an S3 compatible blobstore
 func (client *S3Blobstore) Put(src io.ReadSeeker, dest string) error {
-	if client.s3cliConfig.CredentialsSource == config.NoneCredentialsSource {
+	cfg := client.s3cliConfig
+	if cfg.CredentialsSource == config.NoneCredentialsSource {
 		return errorInvalidCredentialsSourceValue
 	}
 
 	uploader := s3manager.NewUploaderWithClient(client.s3Client)
 	putResult, err := uploader.Upload(&s3manager.UploadInput{
-		Body:   src,
-		Bucket: aws.String(client.s3cliConfig.BucketName),
-		Key:    aws.String(dest),
+		Body:                 src,
+		Bucket:               aws.String(cfg.BucketName),
+		Key:                  aws.String(dest),
+		ServerSideEncryption: cfg.ServerSideEncryption,
+		SSEKMSKeyID:          cfg.SSEKMSKeyID,
 	})
 
 	if err != nil {

--- a/src/s3cli/client/client.go
+++ b/src/s3cli/client/client.go
@@ -32,6 +32,12 @@ func New(configFile io.Reader) (S3Blobstore, error) {
 		return S3Blobstore{}, err
 	}
 
+	s3Client := MakeClient(c)
+
+	return S3Blobstore{s3Client: s3Client, s3cliConfig: c}, nil
+}
+
+func MakeClient(c config.S3Cli) *s3.S3 {
 	transport := *http.DefaultTransport.(*http.Transport)
 	transport.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: !c.SSLVerifyPeer,
@@ -66,7 +72,7 @@ func New(configFile io.Reader) (S3Blobstore, error) {
 		setv2Handlers(s3Client)
 	}
 
-	return S3Blobstore{s3Client: s3Client, s3cliConfig: c}, nil
+	return s3Client
 }
 
 // Get fetches a blob from an S3 compatible blobstore
@@ -99,7 +105,7 @@ func (client *S3Blobstore) Put(src io.ReadSeeker, dest string) error {
 		Bucket:               aws.String(cfg.BucketName),
 		Key:                  aws.String(dest),
 		ServerSideEncryption: cfg.ServerSideEncryption,
-		SSEKMSKeyID:          cfg.SSEKMSKeyID,
+		SSEKMSKeyId:          cfg.SSEKMSKeyID,
 	})
 
 	if err != nil {

--- a/src/s3cli/config/config.go
+++ b/src/s3cli/config/config.go
@@ -10,17 +10,19 @@ import (
 
 // The S3Cli represents configuration for the s3cli
 type S3Cli struct {
-	AccessKeyID        string `json:"access_key_id"`
-	SecretAccessKey    string `json:"secret_access_key"`
-	BucketName         string `json:"bucket_name"`
-	CredentialsSource  string `json:"credentials_source"`
-	Host               string `json:"host"`
-	Port               int    `json:"port"` // 0 means no custom port
-	Region             string `json:"region"`
-	SSLVerifyPeer      bool   `json:"ssl_verify_peer"`
-	UseSSL             bool   `json:"use_ssl"`
-	SignatureVersion   int    `json:"signature_version,string"`
-	UseV2SigningMethod bool
+	AccessKeyID          string  `json:"access_key_id"`
+	SecretAccessKey      string  `json:"secret_access_key"`
+	BucketName           string  `json:"bucket_name"`
+	CredentialsSource    string  `json:"credentials_source"`
+	Host                 string  `json:"host"`
+	Port                 int     `json:"port"` // 0 means no custom port
+	Region               string  `json:"region"`
+	SSLVerifyPeer        bool    `json:"ssl_verify_peer"`
+	UseSSL               bool    `json:"use_ssl"`
+	SignatureVersion     int     `json:"signature_version,string"`
+	ServerSideEncryption *string `json:"server_side_encryption"`
+	SSEKMSKeyID          *string `json:"sse_kms_key_id"`
+	UseV2SigningMethod   bool
 }
 
 // EmptyRegion is required to allow us to use the AWS SDK against S3 compatible blobstores which do not have

--- a/src/s3cli/integration/general_aws_test.go
+++ b/src/s3cli/integration/general_aws_test.go
@@ -5,6 +5,8 @@ import (
 	"s3cli/config"
 	"s3cli/integration"
 
+	"github.com/aws/aws-sdk-go/aws"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -50,6 +52,26 @@ var _ = Describe("General testing for all AWS regions", func() {
 		)
 		DescribeTable("Invoking `s3cli delete` on a non-existent-key does not fail",
 			func(cfg *config.S3Cli) { integration.AssertDeleteNonexistentWorks(s3CLIPath, cfg) },
+			configurations...,
+		)
+
+		configurations = []TableEntry{
+			Entry("with encryption", &config.S3Cli{
+				AccessKeyID:          accessKeyID,
+				SecretAccessKey:      secretAccessKey,
+				BucketName:           bucketName,
+				Region:               region,
+				ServerSideEncryption: aws.String("AES256"),
+			}),
+			Entry("without encryption", &config.S3Cli{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				BucketName:      bucketName,
+				Region:          region,
+			}),
+		}
+		DescribeTable("Invoking `s3cli put` uploads with options",
+			func(cfg *config.S3Cli) { integration.AssertPutOptionsApplied(s3CLIPath, cfg) },
 			configurations...,
 		)
 	})


### PR DESCRIPTION
Accept `ServerSideEncryption` and `SSEKMSKeyID` config options and pass to `Upload`. Since these options have type `*string`, uploading works as normal if the options aren't set.

[Resolves #5]