### PR TITLE
Exit retry loop after successful upload

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -129,6 +129,7 @@ func (client *S3Blobstore) Put(src io.ReadSeeker, dest string) error {
 		}
 
 		log.Println("Successfully uploaded file to", putResult.Location)
+		break
 	}
 
 	return nil


### PR DESCRIPTION
The retry loop needs to break after a successful upload, otherwise the file is going to be uploaded multiple times.