### PR TITLE
Adds support for disabling multipart uploads

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,7 @@ type S3Blobstore struct {
 }
 
 var errorInvalidCredentialsSourceValue = errors.New("the client operates in read only mode. Change 'credentials_source' parameter value ")
+var oneTB = int64(1000 * 1024 * 1024 * 1024)
 
 // New returns a BlobstoreClient if the configuration file backing configFile is valid
 func New(s3Client *s3.S3, s3cliConfig *config.S3Cli) (S3Blobstore, error) {
@@ -54,6 +55,11 @@ func (client *S3Blobstore) Put(src io.ReadSeeker, dest string) error {
 
 	uploader := s3manager.NewUploaderWithClient(client.s3Client, func(u *s3manager.Uploader) {
 		u.LeavePartsOnError = false
+
+		if !cfg.MultipartUpload {
+			// disable multipart uploads by way of large PartSize configuration
+			u.PartSize = oneTB
+		}
 	})
 	uploadInput := &s3manager.UploadInput{
 		Body:   src,

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type S3Cli struct {
 	ServerSideEncryption string `json:"server_side_encryption"`
 	SSEKMSKeyID          string `json:"sse_kms_key_id"`
 	UseV2SigningMethod   bool
+	MultipartUpload      bool
 }
 
 // EmptyRegion is required to allow us to use the AWS SDK against S3 compatible blobstores which do not have
@@ -126,6 +127,8 @@ func NewFromReader(reader io.Reader) (S3Cli, error) {
 		}
 	}
 
+	c.MultipartUpload = c.allowMultipart()
+
 	return c, nil
 }
 
@@ -148,6 +151,15 @@ func (c *S3Cli) S3Endpoint() string {
 func (c *S3Cli) isAWSHost() bool {
 	_, hasKey := awsHostToRegion[c.Host]
 	return hasKey
+}
+
+func (c *S3Cli) allowMultipart() bool {
+	for _, host := range multipartBlacklist {
+		if host == c.Host {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *S3Cli) getRegionFromHost() string {

--- a/config/endpoints.go
+++ b/config/endpoints.go
@@ -23,3 +23,7 @@ var awsHostToRegion = map[string]string{
 
 	"s3.cn-north-1.amazonaws.com.cn": "cn-north-1",
 }
+
+var multipartBlacklist = []string{
+	"storage.googleapis.com",
+}

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -1,10 +1,14 @@
 package integration
 
 import (
+	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/pivotal-golang/s3cli/client"
 	"github.com/pivotal-golang/s3cli/config"
@@ -155,4 +159,74 @@ func AssertDeleteNonexistentWorks(s3CLIPath string, cfg *config.S3Cli) {
 	s3CLISession, err := RunS3CLI(s3CLIPath, configPath, "delete", "non-existent-file")
 	Expect(err).ToNot(HaveOccurred())
 	Expect(s3CLISession.ExitCode()).To(BeZero())
+}
+
+func AssertOnMultipartUploads(s3CLIPath string, cfg *config.S3Cli, content string) {
+	s3Filename := GenerateRandomString()
+	sourceContent := strings.NewReader(content)
+
+	configPath := MakeConfigFile(cfg)
+	defer func() { _ = os.Remove(configPath) }()
+
+	configFile, err := os.Open(configPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	s3Config, err := config.NewFromReader(configFile)
+	Expect(err).ToNot(HaveOccurred())
+
+	s3Client, err := client.NewSDK(s3Config)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	tracedS3, calls := traceS3(s3Client)
+
+	blobstoreClient, err := client.New(tracedS3, &s3Config)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = blobstoreClient.Put(sourceContent, s3Filename)
+	Expect(err).ToNot(HaveOccurred())
+
+	switch cfg.Host {
+	case "storage.googleapis.com":
+		Expect(*calls).To(Equal([]string{"PutObject"}))
+	default:
+		Expect(*calls).To(Equal([]string{"CreateMultipart", "UploadPart", "UploadPart", "CompleteMultipart"}))
+	}
+}
+
+func traceS3(svc *s3.S3) (*s3.S3, *[]string) {
+	var m sync.Mutex
+	calls := []string{}
+	partNum := 0
+
+	svc.Handlers.Send.Clear()
+	svc.Handlers.Send.PushBack(func(r *request.Request) {
+		m.Lock()
+		defer m.Unlock()
+
+		r.HTTPResponse = &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+		}
+
+		switch data := r.Data.(type) {
+		case *s3.CreateMultipartUploadOutput:
+			calls = append(calls, "CreateMultipart")
+			data.UploadId = aws.String("UPLOAD-ID")
+		case *s3.UploadPartOutput:
+			calls = append(calls, "UploadPart")
+			partNum++
+			data.ETag = aws.String(fmt.Sprintf("ETAG%d", partNum))
+		case *s3.CompleteMultipartUploadOutput:
+			calls = append(calls, "CompleteMultipart")
+			data.Location = aws.String("https://location")
+			data.VersionId = aws.String("VERSION-ID")
+		case *s3.PutObjectOutput:
+			calls = append(calls, "PutObject")
+			data.VersionId = aws.String("VERSION-ID")
+		}
+	})
+
+	return svc, &calls
 }

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -64,10 +64,9 @@ func AssertLifecycleWorks(s3CLIPath string, cfg *config.S3Cli) {
 	Expect(s3CLISession.Err.Contents()).To(MatchRegexp("File '.*' does not exist in bucket '.*'"))
 }
 
-func AssertOnPutFailures(s3CLIPath string, cfg *config.S3Cli, errorMessage string) {
-	expectedString := GenerateRandomString(1024 * 1024 * 6)
+func AssertOnPutFailures(s3CLIPath string, cfg *config.S3Cli, content, errorMessage string) {
 	s3Filename := GenerateRandomString()
-	sourceContent := strings.NewReader(expectedString)
+	sourceContent := strings.NewReader(content)
 
 	configPath := MakeConfigFile(cfg)
 	defer func() { _ = os.Remove(configPath) }()

--- a/integration/general_aws_test.go
+++ b/integration/general_aws_test.go
@@ -83,7 +83,7 @@ var _ = Describe("General testing for all AWS regions", func() {
 					Host:            "localhost",
 				}
 				msg := "upload failure"
-				integration.AssertOnPutFailures(s3CLIPath, cfg, msg)
+				integration.AssertOnPutFailures(s3CLIPath, cfg, largeContent, msg)
 			})
 		})
 
@@ -96,7 +96,7 @@ var _ = Describe("General testing for all AWS regions", func() {
 					Region:          region,
 				}
 				msg := "upload retry limit exceeded"
-				integration.AssertOnPutFailures(s3CLIPath, cfg, msg)
+				integration.AssertOnPutFailures(s3CLIPath, cfg, largeContent, msg)
 			})
 		})
 	})

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/pivotal-golang/s3cli/integration"
 
 	"testing"
 )
@@ -16,11 +17,13 @@ func TestIntegration(t *testing.T) {
 }
 
 var s3CLIPath string
+var largeContent string
 
 var _ = BeforeSuite(func() {
 	// Running the IAM tests within an AWS Lambda environment
 	// require a pre-compiled binary
 	s3CLIPath = os.Getenv("S3_CLI_PATH")
+	largeContent = integration.GenerateRandomString(1024 * 1024 * 6)
 
 	if len(s3CLIPath) == 0 {
 		var err error

--- a/integration/s3_compatible_test.go
+++ b/integration/s3_compatible_test.go
@@ -21,6 +21,8 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 		s3PortString := os.Getenv("S3_PORT")
 		s3Port, atoiErr := strconv.Atoi(s3PortString)
 
+		content := ""
+
 		BeforeEach(func() {
 			Expect(accessKeyID).ToNot(BeEmpty(), "ACCESS_KEY_ID must be set")
 			Expect(secretAccessKey).ToNot(BeEmpty(), "SECRET_ACCESS_KEY must be set")
@@ -28,6 +30,11 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 			Expect(s3Host).ToNot(BeEmpty(), "S3_HOST must be set")
 			Expect(s3PortString).ToNot(BeEmpty(), "S3_PORT must be set")
 			Expect(atoiErr).ToNot(HaveOccurred())
+
+			// content... large enough to trigger multipart uploads
+			if content == "" {
+				content = integration.GenerateRandomString(1024 * 1024 * 6)
+			}
 		})
 
 		configurations := []TableEntry{
@@ -75,6 +82,10 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 		)
 		DescribeTable("Invoking `s3cli delete` on a non-existent-key does not fail",
 			func(cfg *config.S3Cli) { integration.AssertDeleteNonexistentWorks(s3CLIPath, cfg) },
+			configurations...,
+		)
+		DescribeTable("Invoking `s3cli put` handling of mulitpart uploads",
+			func(cfg *config.S3Cli) { integration.AssertOnMultipartUploads(s3CLIPath, cfg, content) },
 			configurations...,
 		)
 	})

--- a/integration/s3_compatible_test.go
+++ b/integration/s3_compatible_test.go
@@ -21,8 +21,6 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 		s3PortString := os.Getenv("S3_PORT")
 		s3Port, atoiErr := strconv.Atoi(s3PortString)
 
-		content := ""
-
 		BeforeEach(func() {
 			Expect(accessKeyID).ToNot(BeEmpty(), "ACCESS_KEY_ID must be set")
 			Expect(secretAccessKey).ToNot(BeEmpty(), "SECRET_ACCESS_KEY must be set")
@@ -30,11 +28,6 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 			Expect(s3Host).ToNot(BeEmpty(), "S3_HOST must be set")
 			Expect(s3PortString).ToNot(BeEmpty(), "S3_PORT must be set")
 			Expect(atoiErr).ToNot(HaveOccurred())
-
-			// content... large enough to trigger multipart uploads
-			if content == "" {
-				content = integration.GenerateRandomString(1024 * 1024 * 6)
-			}
 		})
 
 		configurations := []TableEntry{
@@ -85,7 +78,7 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 			configurations...,
 		)
 		DescribeTable("Invoking `s3cli put` handling of mulitpart uploads",
-			func(cfg *config.S3Cli) { integration.AssertOnMultipartUploads(s3CLIPath, cfg, content) },
+			func(cfg *config.S3Cli) { integration.AssertOnMultipartUploads(s3CLIPath, cfg, largeContent) },
 			configurations...,
 		)
 	})


### PR DESCRIPTION
The initial impetus for this change is the fact that GCS, in
"S3-compatibility mode", does not support multipart HTTP uploads.

Rather than provide a configuration option, we decided to embed
the logic internally using a blacklist of non-multipart-upload hosts. In
this way, consumers of `s3cli` do not need to know to set some
configuration when using GCS.

[#126552613](https://www.pivotaltracker.com/story/show/126552613)