### PR TITLE
add a unit test for providing port

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -400,7 +400,7 @@ var _ = Describe("BlobstoreClient configuration", func() {
 		})
 	})
 
-	Describe("returning the alicloud region", func() {
+	Describe("returning the alibaba cloud region", func() {
 		Context("when host is provided", func() {
 			It("returns a region id in the public `host`", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region.aliyuncs.com"}`)
@@ -419,6 +419,46 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				Expect(c.Region).To(Equal("some-region"))
 			})
 			It("returns a empty string if `host` is empty", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": ""}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.S3Endpoint()).To(Equal(""))
+			})
+		})
+	})
+
+	Describe("returning the alibaba cloud endpoint", func() {
+		Context("when port is provided", func() {
+			It("returns a URI in the form `host:port`", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region.aliyuncs.com", "port": 443}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.S3Endpoint()).To(Equal("oss-some-region.aliyuncs.com:443"))
+			})
+			It("returns a empty string URI if `host` is empty", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "", "port": 443}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.S3Endpoint()).To(Equal(""))
+			})
+		})
+
+		Context("when port is not provided", func() {
+			It("returns a URI in the form `host` only", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "oss-some-region.aliyuncs.com"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				c, err := config.NewFromReader(dummyJSONReader)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c.S3Endpoint()).To(Equal("oss-some-region.aliyuncs.com"))
+			})
+			It("returns a empty string URI if `host` is empty", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": ""}`)
 				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
 


### PR DESCRIPTION
This PR aims to add a unit test for alibaba cloud. It apply to validate endpoint when port is provided.

The result of unit tests as following:
```
ginkgo -r -race -skipPackage=integration ./
Will skip:
  ./integration
Running Suite: Config Suite
===========================
Random Seed: 1523291675
Will run 58 of 58 specs

••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 58 of 58 Specs in 0.006 seconds
SUCCESS! -- 58 Passed | 0 Failed | 0 Pending | 0 Skipped PASS

Ginkgo ran 1 suite in 2.686617406s
Test Suite Passed
```

Looking forward to your new feedback. Thanks a lot.

Regards
Guimin He