### PR TITLE
enable omission of config.json / read config from env; add debug option

### DIFF
--- a/client/sdk.go
+++ b/client/sdk.go
@@ -71,6 +71,9 @@ func NewAwsS3Client(c *s3cli_config.S3Cli) (*s3.Client, error) {
 			}
 			o.BaseEndpoint = aws.String(endpoint)
 		}
+		if c.Debug {
+			o.ClientLogMode = aws.LogResponse | aws.LogRequest
+		}
 	})
 
 	return s3Client, nil

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -23,7 +24,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	configFile, err := os.Open(*configPath)
+	var configFile io.Reader
+	var err error
+	if *configPath == "" {
+		configFile, err = config.ConfigFromEnv()
+	} else {
+		configFile, err = os.Open(*configPath)
+	}
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
For usage in CI pipelines, configuration via env instead of json file seemed like a good idea to me.
Tried to make that happen, minimally invasive.
Also added a debug flag - currently only available by setting `S3_DEBUG` to a non-zero string.

Will happily enhance README with usage details in case the overall idea seems sound.