### PR TITLE
Add default region to config for GCP endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,8 @@ type S3Cli struct {
 	UploadPartSize      int64 `json:"upload_part_size"`
 }
 
-const defaultAWSRegion = "us-east-1" //nolint:unused
+const defaultAWSRegion = "us-east-1"
+const defaultGoogleRegion = "us-east-1"
 
 // StaticCredentialsSource specifies that credentials will be supplied using access_key_id and secret_access_key
 const StaticCredentialsSource = "static"
@@ -179,6 +180,9 @@ func (c *S3Cli) configureAlicloud() {
 func (c *S3Cli) configureGoogle() {
 	c.MultipartUpload = false
 	c.RequestChecksumCalculationEnabled = false
+	if c.Region == "" {
+		c.Region = defaultGoogleRegion
+	}
 }
 
 func (c *S3Cli) configureGDCH() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,11 +44,11 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "storage.googleapis.com"}`)
 				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
 
-				It("stubs the region used for SDK configuration", func() {
+				It("sets the default region used for SDK configuration", func() {
 					c, err := config.NewFromReader(dummyJSONReader)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(c.Host).To(Equal("storage.googleapis.com"))
-					Expect(c.Region).To(Equal(""))
+					Expect(c.Region).To(Equal("us-east-1"))
 				})
 			})
 

--- a/integration/s3_compatible_test.go
+++ b/integration/s3_compatible_test.go
@@ -30,6 +30,13 @@ var _ = Describe("Testing in any non-AWS, S3 compatible storage service", func()
 		})
 
 		configurations := []TableEntry{
+			Entry("with minimal configuration", &config.S3Cli{
+				AccessKeyID:     accessKeyID,
+				SecretAccessKey: secretAccessKey,
+				BucketName:      bucketName,
+				Host:            s3Host,
+				MultipartUpload: true,
+			}),
 			Entry("with region specified", &config.S3Cli{
 				AccessKeyID:     accessKeyID,
 				SecretAccessKey: secretAccessKey,


### PR DESCRIPTION
Previously `region` wasn't a required config parameter, so adding a default value seems like it could help mitigate failures. The default value being `us-east-1` was chosen because it is the same on AWS.