### PR TITLE
fix: set default region in configureDefault() for S3-compatible providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,7 +192,9 @@ func (c *S3Cli) configureGDCH() {
 }
 
 func (c *S3Cli) configureDefault() {
-	// No specific configuration needed for default/unknown providers
+	if c.Region == "" {
+		c.Region = defaultAWSRegion
+	}
 }
 
 // S3Endpoint returns the S3 URI to use if custom host information has been provided

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -88,6 +88,18 @@ var _ = Describe("BlobstoreClient configuration", func() {
 				})
 			})
 
+			Context("when a non-AWS custom host is set but no region (S3-compatible provider)", func() {
+				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "my-dell-s3.example.com"}`)
+				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
+
+				It("defaults region to us-east-1 for S3-compatible SDK initialization", func() {
+					c, err := config.NewFromReader(dummyJSONReader)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(c.Host).To(Equal("my-dell-s3.example.com"))
+					Expect(c.Region).To(Equal("us-east-1"))
+				})
+			})
+
 			Context("when AWS host and region have been set", func() {
 				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "s3.amazonaws.com", "region": "us-west-1"}`)
 				dummyJSONReader := bytes.NewReader(dummyJSONBytes)
@@ -240,7 +252,7 @@ var _ = Describe("BlobstoreClient configuration", func() {
 					"access_key_id":      "id",
 					"secret_access_key":  "key",
 					"bucket_name":        "some-bucket",
-					"host": 	      "storage.googleapis.com"
+					"host":               "my-s3-compatible.example.com"
 				}`)
 
 				configReader := bytes.NewReader(configBytes)


### PR DESCRIPTION
## Problem

Generic S3-compatible blobstores (Dell EMC ECS, Minio, etc.) configured with a custom \`host\` but no \`region\` fail with:

```
A region must be set when sending requests to S3
```

This affects deployments using stemcell Jammy v1.1033+, which bundles \`bosh-s3cli v0.0.383+\` (the AWS SDK Go v2 migration).

## Root Cause

AWS SDK Go v2's endpoint rules engine (BDD) checks for a non-empty \`Region\` as its **very first, unconditional step** before evaluating any other parameters — including whether a custom \`BaseEndpoint\` is set. If \`Region\` is empty, it immediately returns the error above, regardless of endpoint configuration.

When the configured \`host\` does not match any known provider (AWS, Google, Alicloud, GDCH), \`configureDefault()\` is called. Commit \`31e709f\` (Dec 2025) removed the default-region guard from that function under the assumption that providing a custom endpoint would bypass the region check. That assumption is incorrect for SDK v2.

This was tested by creating this test:
```
			Context("when a non-AWS custom host is set but no region (S3-compatible provider)", func() {
				dummyJSONBytes := []byte(`{"access_key_id": "id", "secret_access_key": "key", "bucket_name": "some-bucket", "host": "my-dell-s3.example.com"}`)
				dummyJSONReader := bytes.NewReader(dummyJSONBytes)

				It("defaults region to us-east-1 for S3-compatible SDK initialization", func() {
					c, err := config.NewFromReader(dummyJSONReader)
					Expect(err).ToNot(HaveOccurred())
					Expect(c.Host).To(Equal("my-dell-s3.example.com"))
					Expect(c.Region).To(Equal("us-east-1"))
				})
			})
```

which failed before the region was set.
			
## Fix

Restore the default-region guard in \`configureDefault()\`, matching the behaviour already present in \`configureAWS()\` and \`configureGoogle()\`.

```
func (c *S3Cli) configureDefault() {
    if c.Region == "" {
        c.Region = defaultAWSRegion
    }
}
```

The value \`"us-east-1"\` is a well-known placeholder that satisfies the SDK's SigV4 signing requirement. For S3-compatible endpoints the region value is typically ignored by the server — customers who care about it can still set it explicitly via the \`region\` config field, in which case the guard is a no-op.

## Tests

- Added a new regression test: \`"when a non-AWS custom host is set but no region (S3-compatible provider)"\` — verified it **fails** on the unfixed code, then **passes** after the fix.
- Fixed the mislabelled \`"when Default provider"\` host-style test that was inadvertently using \`storage.googleapis.com\` (Google provider) instead of a generic host.

## References

- Original SDK v2 migration PR (commit \`31e709f\`)

Made with [Cursor](https://cursor.com)